### PR TITLE
Emissary-Ingress auth and certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ In here you will find:
   https://demo.cluster.local/faces/ and the Linkerd Viz dashboard is available at
   https://demo.cluster.local/
 
+   - To login using basic auth, use the credentials `username` and `password`
+
+   - To remove the need for authentication run `$ kubectl delete authservice -n emissary authentication`
+
 - To run the demo as we've given it before, check out [DEMO.md]. The easiest
   way to use that is to run it with [demosh].
 
@@ -65,3 +69,10 @@ In here you will find:
 
 There are many `#@` comments in the shell scripts; those are hooks to be
 interpreted by external software. You can safely ignore them for now.
+
+#### Certificates
+For maximum flexibility of running locally or in an ephemeral environment
+this demo uses self-signed certificates. For reference on how you could create
+real certificates in a production environment, view our [example](./cert-manager-yaml/production-cert-example)
+which uses a DNS01 solver to get a certificate from Let's Encrypt for your domain.
+

--- a/cert-manager-yaml/production-cert-example.yaml
+++ b/cert-manager-yaml/production-cert-example.yaml
@@ -1,0 +1,93 @@
+# This file shows examples of cert-manager resources to get a
+# cert from Let's Encrypt using the DNS01 solver, with Cloudflare
+# as the DNS management vendor. cert-manager supports several other
+# vendors, as well as webhooks and a generic ACMEDNS server, you can see
+# all of them, with instructions for use, at https://cert-manager.io/docs/configuration/acme/dns01/
+
+# create a secret for cert-manager to use to authenticate with
+# the DNS management vendor
+#---
+#apiVersion: v1
+#kind: Secret
+#metadata:
+#  name: cloudflare-api-token
+#  namespace: cert-manager
+#stringData:
+#  api-token: <a Cloudflare API token>
+
+# Create staging and production ClusterIssuers. With Let's Encrypt
+# it is critical to test your configuration against their staging server
+# first, as it is easy to go over the production rate limit with a
+# failing configuration and be stuck.
+#---
+#apiVersion: cert-manager.io/v1
+#kind: ClusterIssuer
+#metadata:
+#  name: letsencrypt-staging
+#  namespace: cert-manager
+#spec:
+#  acme:
+#    email: "dev@company.com"
+#    server: "https://acme-staging-v02.api.letsencrypt.org/directory"
+#    privateKeySecretRef:
+#      name: le-staging-issuer-account-key
+#    solvers:
+#      - dns01:
+#          cloudflare:
+#            apiTokenSecretRef:
+#              name: cloudflare-api-token
+#              key: api-token
+#---
+#apiVersion: cert-manager.io/v1
+#kind: ClusterIssuer
+#metadata:
+#  name: letsencrypt-production
+#  namespace: cert-manager
+#spec:
+#  acme:
+#    email: "dev@company.com"
+#    server: "https://acme-v02.api.letsencrypt.org/directory"
+#    privateKeySecretRef:
+#      name: le-production-issuer-account-key
+#    solvers:
+#    - dns01:
+#        cloudflare:
+#          apiTokenSecretRef:
+#            name: cloudflare-api-token
+#            key: api-token
+
+# Create a staging certificate to test the configuration before
+# attempting to create a production certificate.
+#---
+#apiVersion: cert-manager.io/v1
+#kind: Certificate
+#metadata:
+#  name: demo-staging
+#  namespace: emissary
+#spec:
+#  secretName: demo-mycompany-com-staging
+#  duration: 2160h
+#  renewBefore: 360h
+#  dnsNames:
+#  - demo.mycompany.com
+#  issuerRef:
+#    name: letsencrypt-staging
+#    kind: ClusterIssuer
+
+# Once the staging certificate is successfully created, we can
+# create a production one for use with the Emissary-Ingress host.
+#---
+#apiVersion: cert-manager.io/v1
+#kind: Certificate
+#metadata:
+#  name: demo
+#  namespace: emissary
+#spec:
+#  secretName: demo-mycompany-com
+#  duration: 2160h
+#  renewBefore: 360h
+#  dnsNames:
+#    - demo.mycompany.com
+#  issuerRef:
+#    name: letsencrypt-production
+#    kind: ClusterIssuer

--- a/emissary-yaml/auth.yaml
+++ b/emissary-yaml/auth.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-auth
+  namespace: emissary
+spec:
+  type: ClusterIP
+  selector:
+    app: example-auth
+  ports:
+    - port: 3000
+      name: http-example-auth
+      targetPort: http-api
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-auth
+  namespace: emissary
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: example-auth
+  template:
+    metadata:
+      labels:
+        app: example-auth
+    spec:
+      containers:
+        - name: example-auth
+          image: thedevelopnik/ambassador-auth-service:1.1.1
+          imagePullPolicy: Always
+          ports:
+            - name: http-api
+              containerPort: 3000
+          resources:
+            limits:
+              cpu: "0.1"
+              memory: 100Mi
+          startupProbe:
+            httpGet:
+              path: /
+              port: http-api
+            failureThreshold: 30
+            periodSeconds: 10
+---
+apiVersion: getambassador.io/v3alpha1
+kind: AuthService
+metadata:
+  name: authentication
+  namespace: emissary
+spec:
+  auth_service: "example-auth:3000"
+  path_prefix: "/extauth"
+  allowed_request_headers:
+    - "x-faces-session"
+  allowed_authorization_headers:
+    - "x-faces-session"


### PR DESCRIPTION
This adds a basic auth extension service that requires end users to authenticate against all paths. To access the Faces app with it enabled, you use `username` and `password`. It's a [fork](https://github.com/thedevelopnik/ambassador-auth-service) of the service used in the [Emissary tutorial](https://www.getambassador.io/docs/emissary/latest/howtos/basic-auth).

It also adds a file providing examples of how to get real Let's Encrypt certificates if you are in an environment where you have control over the DNS provider. These examples are commented out, so they don't auto-apply, since they require publicly accessible DNS and authentication with the provider.