### PR TITLE
Add trust-manager example

### DIFF
--- a/install-cert-manager-and-vault.sh
+++ b/install-cert-manager-and-vault.sh
@@ -11,6 +11,12 @@ helm upgrade cert-manager jetstack/cert-manager \
 
 kubectl apply --server-side -f ./vault-server-tls.yaml
 
+# Install trust-manager
+helm upgrade trust-manager jetstack/trust-manager \
+  --install \
+  --namespace cert-manager \
+  --wait
+
 # Install Vault
 helm repo add hashicorp https://helm.releases.hashicorp.com
 helm upgrade vault hashicorp/vault \

--- a/trust-manager-yaml/bundle.yaml
+++ b/trust-manager-yaml/bundle.yaml
@@ -1,0 +1,17 @@
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: public-ca-bundle
+  namespace: faces
+
+spec:
+  sources:
+  - useDefaultCAs: true
+
+  target:
+    configMap:
+      key: "cacert.pem"
+
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: faces

--- a/trust-manager-yaml/deployment.yaml
+++ b/trust-manager-yaml/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-public-endpoint
+  namespace: faces
+spec:
+  selector:
+    matchLabels:
+      app: test-public-endpoint
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: test-public-endpoint
+    spec:
+      volumes:
+      - name: configmap-ca-volume
+        configMap:
+          name: public-ca-bundle
+          optional: false
+      containers:
+      - name: test-public-endpoint
+        image: curlimages/curl:latest
+        # every 15 seconds, we fetch the public URL and verify that TLS is working as expected
+        command: ["/bin/sh", "-c"]
+        args:
+          - while sleep 15; do curl --cacert /cacert.pem https://kubecrash.demo.59s.io/faces/; done
+        volumeMounts:
+        - name: configmap-ca-volume
+          mountPath: "/cacert.pem" # this is the cacert location that CURL uses in this image
+          subPath: "cacert.pem"
+          readOnly: true


### PR DESCRIPTION
Added a minimal trust-manager example. The example fetches the public endpoint every 15 seconds and validates that the certificate is publicly trusted.
